### PR TITLE
Don't raise exceptions caused by reporting to Airbrake

### DIFF
--- a/django_airbrake/middleware.py
+++ b/django_airbrake/middleware.py
@@ -8,4 +8,8 @@ class AirbrakeNotifierMiddleware(object):
 
     def process_exception(self, request, exception):
         if hasattr(settings, 'AIRBRAKE') and not settings.AIRBRAKE.get('DISABLE', False):
-            self.client.notify(exception=exception, request=request)
+            try:
+                self.client.notify(exception=exception, request=request)
+            # Ignore failures from issues like rate limiting
+            except:
+                pass


### PR DESCRIPTION
For @yorinasub17 

JIRA: [REL-175](https://captricity.atlassian.net/browse/REL-175)

Prevents our airbrake middleware from raising exceptions when the client throws an error.
